### PR TITLE
Fix OneHotEncoder usage

### DIFF
--- a/FlightPrediction.ipynb
+++ b/FlightPrediction.ipynb
@@ -2216,22 +2216,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import OneHotEncoder\n",
+    "ohe = OneHotEncoder()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c9a1342c",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'ohe' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[44]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mohe\u001b[49m.fit_transform(np.array(final_df[\u001b[33m'\u001b[39m\u001b[33mAirline\u001b[39m\u001b[33m'\u001b[39m]).reshape(-\u001b[32m1\u001b[39m,\u001b[32m1\u001b[39m))\n",
-      "\u001b[31mNameError\u001b[39m: name 'ohe' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ohe.fit_transform(np.array(final_df['Airline']).reshape(-1,1))\n"
    ]


### PR DESCRIPTION
## Summary
- include OneHotEncoder initialization before usage in `FlightPrediction.ipynb`
- clear previous error output

## Testing
- `pytest -q`
- `jupyter nbconvert --execute FlightPrediction.ipynb --to notebook --output executed.ipynb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffa6a8950832092c610a2dec92390